### PR TITLE
use binary path from Qt.application.arguments

### DIFF
--- a/ExportStaffMP3s.qml
+++ b/ExportStaffMP3s.qml
@@ -68,39 +68,15 @@ MuseScore {
         return path
     }
     function exportMP3(infile, outfile) {
-        if (Qt.platform.os=="linux") {
-            var cmd = "musescore \""+infile+"\" -o \""+outfile+"\""
-            proc.start(cmd);
-            var val = proc.waitForFinished(-1);
-            if (val) {
-                console.log(cmd)
-                console.log(val)
-                console.log(proc.readAllStandardOutput())
-            } else {
-                console.log("command failed: "+cmd)
-            }
-        } else if (Qt.platform.os=="windows") {
-            var cmd = 'Powershell.exe -Command "MuseScore3.exe \''+infile+'\' -o \''+outfile+'\'"'
-            proc.start(cmd);
-            var val = proc.waitForFinished(-1);
-            if (val) {
-                console.log(cmd)
-                console.log(val)
-                console.log(proc.readAllStandardOutput())
-            } else {
-                console.log("command failed: "+cmd)
-            }
-        } else if (Qt.platform.os=="osx") {
-            var cmd = 'open -j -W -n "/Applications/MuseScore 3.app" --args "'+infile+'" -o "'+outfile+'"'
-            proc.start(cmd);
-            var val = proc.waitForFinished(-1);
-            if (val) {
-                console.log(cmd)
-                console.log(val)
-                console.log(proc.readAllStandardOutput())
-            } else {
-                console.log("command failed: "+cmd)
-            }
+        var cmd = '"'+Qt.application.arguments[0]+'" "'+infile+'" -o "'+outfile+'"'
+        proc.start(cmd);
+        var val = proc.waitForFinished(-1);
+        if (val) {
+            console.log(cmd)
+            console.log(val)
+            console.log(proc.readAllStandardOutput())
+        } else {
+            console.log("command failed: "+cmd)
         }
     }
     function mkdir(path) {


### PR DESCRIPTION
Run the binary in `Qt.application.arguments[0]` since that is the currently running MuseScore instance.

Tested on Windows 10, Ubuntu 22.04 (Jammy Jellifish) and macOS 11.6.2 (Big Sur).

I'm not really sure about removal of `Powershell.exe -Command` for Windows as it works for me, but maybe I'm missing some side-effect here.

Also I can't recall why I had to add `open -j -W -n` on macOS earlier other than not spawning a full GUI-process, as it seems to work fine without. 